### PR TITLE
PR: Remove Home link in navbar so we can add an external one to our main website

### DIFF
--- a/pandas_sphinx_theme/docs-navbar.html
+++ b/pandas_sphinx_theme/docs-navbar.html
@@ -11,9 +11,6 @@
 
   <div id="navbar-menu" class="collapse navbar-collapse">
     <ul id="navbar-main-elements" class="navbar-nav mr-auto">
-      <li class="nav-item">
-          <a class="nav-link" href="{{ pathto('index') }}">Home</a>
-      </li>
       {% for external_link in theme_external_links %}
         <li class="nav-item">
             <a class="nav-link nav-external" href="{{ external_link.url }}">{{ external_link.name }}</a>


### PR DESCRIPTION
This is the solution suggested by @dalthviz.