### PR TITLE
PR: Update URL to OC donate graphic in footer to match new one on site

### DIFF
--- a/pandas_sphinx_theme/footer.html
+++ b/pandas_sphinx_theme/footer.html
@@ -19,7 +19,7 @@
         {% if theme_open_collective %}
         <div class="row justify-content-center">
             <a href="https://opencollective.com/{{theme_open_collective}}/donate" target="_blank">
-              <img src="https://www.spyder-ide.org/static/images/collective.svg" class="center donate" />
+              <img src="https://www.spyder-ide.org/collective.svg" class="center donate" />
             </a>
         </div>
         {% endif %}


### PR DESCRIPTION
The URL for the donate graphic is out of date, which makes it not load in the footer. This PR updates it to the current one; after this is merged we can just retrigger a Travis build of the docs site to pull in the updated version.