### PR TITLE
PR: Add block for alertmessage, to allow it to be overridden easily (e.g. by outdated/dev version header)

### DIFF
--- a/pandas_sphinx_theme/layout.html
+++ b/pandas_sphinx_theme/layout.html
@@ -43,11 +43,13 @@
   <body data-spy="scroll" data-target="" data-offset="60" style="font-size=16px">
 {%- endblock %}
 {%- block content %}
+    {%- block alertmessage %}
     {% if theme_alert_message %}
     <div class="alert-danger text-center" role="alert">
       {{theme_alert_message | safe}}
     </div>
     {% endif %}
+    {%- endblock %}
     <nav class="navbar navbar-light navbar-expand-lg bg-light fixed-top bd-navbar py-0" id="navbar-main">
       {%- include "docs-navbar.html" %}
     </nav>


### PR DESCRIPTION
This simply adds a block around the alert message, to make it easy to override by templates that extend this one. We need it in Spyder-Docs for the dev version/outdated version alert banner.

Required for spyder-ide/spyder-docs#290